### PR TITLE
Virtual directory

### DIFF
--- a/data/osec.cron
+++ b/data/osec.cron
@@ -18,6 +18,8 @@ IGNORE_FIELDS=
 NICE_ARGS=
 IONICE_ARGS='-t'
 HASH_TYPE=
+VIRTUAL_DIR_FILE=
+DATABASE_FILE=
 
 PIPECONF_FILE="/etc/osec/pipe.conf"
 . "${PIPECONF_FILE}"
@@ -117,6 +119,11 @@ case "${IMMUTABLE_DATABASE-}" in
 		;;
 esac
 
+if [ -n "$VIRTUAL_DIR_FILE" ]; then
+    DIRS_FILE="$VIRTUAL_DIR_FILE"
+    DATABASE_DIR="${DATABASE_FILE:-$DATABASE_DIR}"
+fi
+
 (
 	rc=0
 	$cmd /usr/bin/osec \
@@ -125,6 +132,7 @@ esac
 		${HASH_TYPE:+-t "$HASH_TYPE"} \
 		${allow_root:+-R} \
 		${read_only:+-r} \
+		${VIRTUAL_DIR_FILE:+--virtual} \
 		-D "$DATABASE_DIR" \
 		-f "$DIRS_FILE" ||
 		rc=$?

--- a/data/pipe.conf
+++ b/data/pipe.conf
@@ -13,6 +13,15 @@ DATABASE_DIR=/var/lib/osec
 # The list of directories that should be processed.
 DIRS_FILE=/etc/osec/dirs.conf
 
+# Define VIRTUAL_DIR_FILE and DATABASE_FILE in order to
+# run osec in virtual directory mode. In that mode,
+# VIRTUAL_DIR_FILE determines the explicit list of files
+# to check and DATABASE_FILE --- the absolute path to the
+# database file (with no relation to DATABASE_DIR above).
+# Node, that the value EXCLUDE_FILE of is ignored.
+VIRTUAL_DIR_FILE=
+DATABASE_FILE=
+
 # The file contains the patterns of files that will be excluded
 # from the database.
 EXCLUDE_FILE=/etc/osec/exclude.conf

--- a/osec.spec
+++ b/osec.spec
@@ -93,6 +93,9 @@ mkdir -p -- .%osec_statedir
 %triggerpostun -- %name < 0:1.0.0-alt1
 rm -f %osec_statedir/osec.db.*
 
+%check
+%make_build check || ( cat tests/test-suite.log && exit 1 )
+
 %files
 %doc ChangeLog NEWS README src/restore data/osec-recheck
 %_bindir/osec

--- a/src/osec.c
+++ b/src/osec.c
@@ -638,7 +638,10 @@ static bool process(char *dirname)
 		goto end;
 	}
 
-	sprintf(new_dbname, "%s/temp/osec.XXXXXXXXX", db_path);
+	if (virtual_mode)
+		sprintf(new_dbname, "%s.temp.XXXXXXXXX", db_path);
+	else
+		sprintf(new_dbname, "%s/temp/osec.XXXXXXXXX", db_path);
 
 	// Open new database
 	if ((new_fd = mkstemp(new_dbname)) == -1) {
@@ -850,13 +853,13 @@ int main(int argc, char **argv)
 				gcry_strsource(gcrypt_error));
 	}
 
-	recreate_tempdir();
-
 	if (virtual_mode) {
 		if (!process("!VIRTUAL!"))
 			retval = EXIT_FAILURE;
 		goto end;
 	}
+
+	recreate_tempdir();
 
 	char path[MAXPATHLEN];
 

--- a/src/osec.c
+++ b/src/osec.c
@@ -855,7 +855,7 @@ int main(int argc, char **argv)
 	}
 
 	if (virtual_mode) {
-		if (!process("!VIRTUAL!"))
+		if (!process(dirslist_file))
 			retval = EXIT_FAILURE;
 		goto end;
 	}

--- a/src/osec.c
+++ b/src/osec.c
@@ -47,6 +47,7 @@ static void print_help(int ret)
 {
 	printf("Usage: %1$s [OPTIONS] [DIRECTORY...]\n"
 	       "   or: %1$s [OPTIONS] --file=FILE [DIRECTORY...]\n"
+	       "   or: %1$s [OPTIONS] -V -D DBFILE -f LISTFILE\n"
 	       "\n"
 	       "This utility help you to see difference between\n"
 	       "two states of your system.\n"

--- a/src/osec.c
+++ b/src/osec.c
@@ -759,7 +759,7 @@ int main(int argc, char **argv)
 	if (argc == 1)
 		print_help(EXIT_SUCCESS);
 
-	while ((c = getopt_long(argc, argv, "hvnrRi:u:g:D:f:x:X:t:", long_options, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "hvnrRi:u:g:D:f:x:X:t:V", long_options, NULL)) != -1) {
 		switch (c) {
 			case 'v':
 				print_version();

--- a/src/osec.c
+++ b/src/osec.c
@@ -87,9 +87,11 @@ static void print_version(void)
 	printf("%s version " PACKAGE_VERSION "\n"
 	       "Written by Alexey Gladkov <gladkov.alexey@gmail.com>\n"
 	       "Modified by Aleksei Nikiforov <darktemplar@basealt.ru>\n"
+	       "Modified by Paul Wolneykien <manowar@altlinux.org>\n"
 	       "\n"
 	       "Copyright (C) 2008-2020  Alexey Gladkov <gladkov.alexey@gmail.com>\n"
 	       "Copyright (C) 2019  Aleksei Nikiforov <darktemplar@basealt.ru>\n"
+	       "Copyright (C) 2024  Paul Wolneykien <manowar@altlinux.org>\n"
 	       "\n"
 	       "This is free software; see the source for copying conditions.  There is NO\n"
 	       "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n",

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,6 +12,7 @@ check_SCRIPTS = \
 	osec-report-tempdir \
 	osec-report-ww \
 	osec-report-xattr \
+	osec-report-virtual \
 	$(NULL)
 
 TESTS = $(check_SCRIPTS)

--- a/tests/data/osec-report-virtual/osec-1.report
+++ b/tests/data/osec-report-virtual/osec-1.report
@@ -1,0 +1,31 @@
+Init database for vdir.list ...
+root/testfile_00	checksum	new	 checksum=sha1:188d51466bf230309c7d232db058dc574a5df5b3
+root/testfile_00	stat	new	 uid=@USER@ gid=@USER@ mode=100644 inode=@INODE1_testfile_00@
+root/testfile_02	checksum	new	 checksum=sha1:0908cbeb2fbd745cc950e39787ccde1971093238
+root/testfile_02	stat	new	 uid=@USER@ gid=@USER@ mode=100644 inode=@INODE1_testfile_02@
+root/testfile_04	checksum	new	 checksum=sha1:c249d3e14b7a14a3464bf490cafc81d3372fa4da
+root/testfile_04	stat	new	 uid=@USER@ gid=@USER@ mode=100644 inode=@INODE1_testfile_04@
+root/testfile_06	checksum	new	 checksum=sha1:b649682b92a811746098e5c91e891e5142a41950
+root/testfile_06	stat	new	 uid=@USER@ gid=@USER@ mode=100644 inode=@INODE1_testfile_06@
+root/testfile_08	checksum	new	 checksum=sha1:c7e80dc713c241193f886165d0c126d4e5bd4fd5
+root/testfile_08	stat	new	 uid=@USER@ gid=@USER@ mode=100644 inode=@INODE1_testfile_08@
+root/testfile_10	checksum	new	 checksum=sha1:4143d3a341877154d6e95211464e1df1015b74bd
+root/testfile_10	stat	new	 uid=@USER@ gid=@USER@ mode=100644 inode=@INODE1_testfile_10@
+root/testfile_12	checksum	new	 checksum=sha1:ad552e6dc057d1d825bf49df79d6b98eba846ebe
+root/testfile_12	stat	new	 uid=@USER@ gid=@USER@ mode=100644 inode=@INODE1_testfile_12@
+root/testfile_14	checksum	new	 checksum=sha1:030514d80869744a4e2f60d2fd37d6081f5ed01a
+root/testfile_14	stat	new	 uid=@USER@ gid=@USER@ mode=100644 inode=@INODE1_testfile_14@
+root/testfile_16	checksum	new	 checksum=sha1:3596ea087bfdaf52380eae441077572ed289d657
+root/testfile_16	stat	new	 uid=@USER@ gid=@USER@ mode=100644 inode=@INODE1_testfile_16@
+root/testfile_18	checksum	new	 checksum=sha1:24b9c1f3fddff79893e5304f998f2f95ebebd149
+root/testfile_18	stat	new	 uid=@USER@ gid=@USER@ mode=100644 inode=@INODE1_testfile_18@
+root/testlink_00	stat	new	 uid=@USER@ gid=@USER@ mode=120777 inode=@INODE1_testlink_00@
+root/testlink_02	stat	new	 uid=@USER@ gid=@USER@ mode=120777 inode=@INODE1_testlink_02@
+root/testlink_04	stat	new	 uid=@USER@ gid=@USER@ mode=120777 inode=@INODE1_testlink_04@
+root/testlink_06	stat	new	 uid=@USER@ gid=@USER@ mode=120777 inode=@INODE1_testlink_06@
+root/testlink_08	stat	new	 uid=@USER@ gid=@USER@ mode=120777 inode=@INODE1_testlink_08@
+root/testlink_10	stat	new	 uid=@USER@ gid=@USER@ mode=120777 inode=@INODE1_testlink_10@
+root/testlink_12	stat	new	 uid=@USER@ gid=@USER@ mode=120777 inode=@INODE1_testlink_12@
+root/testlink_14	stat	new	 uid=@USER@ gid=@USER@ mode=120777 inode=@INODE1_testlink_14@
+root/testlink_16	stat	new	 uid=@USER@ gid=@USER@ mode=120777 inode=@INODE1_testlink_16@
+root/testlink_18	stat	new	 uid=@USER@ gid=@USER@ mode=120777 inode=@INODE1_testlink_18@

--- a/tests/data/osec-report-virtual/osec-2.report
+++ b/tests/data/osec-report-virtual/osec-2.report
@@ -1,0 +1,6 @@
+Processing vdir.list ...
+root/testfile_02	checksum	changed	old checksum=sha1:0908cbeb2fbd745cc950e39787ccde1971093238	new checksum=sha1:a8fdc205a9f19cc1c7507a60c4f01b13d11d7fd0
+root/testfile_02	stat	changed	old mtime=@MTIME1_testfile_02@	new mtime=@MTIME2_testfile_02@
+root/testfile_06	stat	changed	old mtime=@MTIME1_testfile_06@	new mtime=@MTIME2_testfile_06@
+root/testfile_10	stat	changed	old mtime=@MTIME1_testfile_10@	new mtime=@MTIME2_testfile_10@
+root/testlink_14	stat	changed	old mtime=@MTIME1_testlink_14@	new mtime=@MTIME2_testlink_14@

--- a/tests/osec-report-virtual
+++ b/tests/osec-report-virtual
@@ -1,0 +1,37 @@
+#!/bin/sh -efu
+
+. "${0%/*}/tests-sh-functions"
+
+tc_init
+
+mkdir -p -- "$rootdir"
+
+for n in `seq 0 19`; do
+    n="$(printf '%02d' "$n")"
+    echo "$n" >"$rootdir/testfile_$n"
+    ln -s "testfile_$n" "$rootdir/testlink_$n"
+done
+
+find "$rootdir" \( -type f -o -type l \) -name 'test*_[0-9][02468]' | \
+    sort >"$tmpdir/vdir.list"
+
+tc_state 1
+
+subst < "$datadir/osec-$i.report" > "$tmpdir/expect-$i"
+"$srcdir/osec" -V -D "$tmpdir/vdir.db" -f "$tmpdir/vdir.list" | \
+    subst > "$tmpdir/output-$i"
+diff -u "$tmpdir/expect-$i" "$tmpdir/output-$i"
+
+echo "123" > "$rootdir/testfile_02"
+echo "456" > "$rootdir/testlink_05"
+echo "06" > "$rootdir/testlink_06"
+touch "$rootdir/testfile_10"
+touch -h "$rootdir/testlink_14"
+touch -h "$rootdir/testlink_15"
+
+tc_state 2
+
+subst < "$datadir/osec-$i.report" > "$tmpdir/expect-$i"
+"$srcdir/osec" --virtual -D "$tmpdir/vdir.db" -f "$tmpdir/vdir.list" | \
+    subst > "$tmpdir/output-$i"
+diff -u "$tmpdir/expect-$i" "$tmpdir/output-$i"


### PR DESCRIPTION
The patch introduces the notion of "virtual directory". A virtual directory is not a real filesystem directory, but is a _constant_ set of files, a file list. Why is it needed? It's a simple _whitelist_ approach that can help in situation where a combination of `dirs.conf` + `exclude.conf` doesn't work or is very hard to setup. For instance, watching for changes in a particular set of utils under `/usr/bin` (`/usr/bin/my.*`). Or watching over configuration files in a directory where are also present some temporary and variable data files, i.e.: watching for `/var/lib/pgsql/data/*.conf` but not watching _arbitrary_ other files under `/var/lib/pgsql/data/` (as the database files continuously change).

The patch also switches the tests to be run in the `%check` section of spec in order to be sure the new function (and old ones too) works as expected.